### PR TITLE
:ambulance: Fixes GIT version tag detection issue

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -352,7 +352,7 @@ git_get_info() {
     # Is the GIT repository dirty?
     if [[ -z "$(git status --porcelain)" ]]; then
 
-        tag=$(git describe --exact-match HEAD --abbrev=0 --tags &> /dev/null \
+        tag=$(git describe --exact-match HEAD --abbrev=0 --tags 2> /dev/null \
                 || true)
         ref=$(git rev-parse --short HEAD)
 

--- a/build-env/rootfs/build.sh
+++ b/build-env/rootfs/build.sh
@@ -1038,7 +1038,7 @@ get_info_git() {
     # Is the GIT repository dirty?
     if [[ -z "$(git status --porcelain)" ]]; then
 
-        tag=$(git describe --exact-match HEAD --abbrev=0 --tags &> /dev/null \
+        tag=$(git describe --exact-match HEAD --abbrev=0 --tags 2> /dev/null \
                 || true)
         ref=$(git rev-parse --short HEAD)
 


### PR DESCRIPTION
## Proposed Changes

Fixes an issue with detecting the current version based on GIT tags.

## Related Issues

None