### PR TITLE
:ambulance: :rocket: Adds curl to CircleCI environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - run:
           name: Install dependencies
-          command: apk update && apk upgrade && apk add --nocache git bash
+          command: apk update && apk upgrade && apk add --nocache git bash curl
       - setup_remote_docker
       - run:
           name: Check docker is running


### PR DESCRIPTION
## Proposed Changes

Curl is needed in the build environment to enable Microbadger notifications.

## Related Issues

None