### PR TITLE
:fire: Simplification of the build enviroment

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Options:
         The type of the thing you are building.
         Valid values are: addon, base, cluster, homeassistant and supervisor.
         If you are unsure, then you probably don't need this flag.
-        Defaults to 'addon'.
+        Defaults to auto detect, with failover to 'addon'.
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -63,16 +63,16 @@ Options:
     ------ Build Architectures ------
 
     --aarch64
-        Build for aarch64 architecture.
+        Build for aarch64 (arm 64 bits) architecture.
 
     --amd64
-        Build for amd64 architecture.
+        Build for amd64 (intel/amd 64 bits) architecture.
 
     --armhf
-        Build for armhf architecture.
+        Build for armhf (arm 32 bits) architecture.
 
     --i386
-        Build for i386 architecture.
+        Build for i386 (intel/amd 32 bits) architecture.
 
     -a, --all
         Build for all architectures.
@@ -134,6 +134,7 @@ Options:
 
     --arg <key> <value>
         Pass additional build arguments into the Docker build.
+        This option can be repeated for multiple key/value pairs.
 
     -c, --no-cache
         Disable build from cache.
@@ -156,44 +157,6 @@ Options:
         Valid values are: addon, base, cluster, homeassistant and supervisor.
         If you are unsure, then you probably don't need this flag.
         Defaults to 'addon'.
-
-    -n, --name <name>
-        Name or title of the thing that is being built.
-        Note: When building add-ons; this will override the setting from
-              the configuration file.
-
-    -d, --description <description>
-        Description of the thing that is being built.
-        Note: When building add-ons; this will override the setting from
-              the configuration file.
-
-    --vendor <vendor>
-        The name of the vendor providing the thing that is being built.
-
-    -m, --maintainer, --author <author>
-        Name of the maintainer. MUST be in "My Name <email@example.com>" format.
-        e.g., "Franck Nijhof <frenck@addons.community>"
-        Note: When building add-ons; this will override the setting from
-              the configuration file.
-
-    -u, --url <ur>
-        URL to the homepage of the thing that is built.
-        Note: When building add-ons; this will override the setting from
-              the configuration file.
-
-    -c, --doc-url <url>
-        URL to the documentation of the thing that is built.
-        When omitted, the value of --url will be used.
-
-    --git-url <url>
-        The URL to the GIT repository (e.g., GitHub).
-        When omitted, the value of --url will be used or is detected using git.
-
-    -o, --override
-        Always override Docker labels.
-        The normal behavior of the builder is to only add a label when it is
-        not found in the Dockerfile. This flag enforces to override all label
-        values.
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -81,34 +81,6 @@ Options:
         a configuration file, that list is still honored when using
         this flag.
 
-    ------ Build base images ------
-
-    --aarch64-from <image>
-        Use a custom base image when building for aarch64.
-        e.g. --aarch64-image "homeassistant/aarch64-base".
-        Note: This overrides the --from flag for this architecture.
-
-    --amd64-from <image>
-        Use a custom base image when building for amd64.
-        e.g. --amd64-image "homeassistant/amd64-base".
-        Note: This overrides the --from flag for this architecture.
-
-    --armhf-from <image>
-        Use a custom base image when building for armhf.
-        e.g. --armhf-image "homeassistant/armhf-base".
-        Note: This overrides the --from flag for this architecture.
-
-    --i386-from <image>
-        Use a custom base image when building for i386.
-        e.g. --i386-image "homeassistant/i386-image".
-        Note: This overrides the --from flag for this architecture.
-
-    -f, --from <image>
-        Use a custom base image when building.
-        Use '{arch}' as a placeholder for the architecture name.
-        e.g., --from "homeassistant/{arch}-base"
-        Defaults to "hassioaddons/base-{arch}"
-
     ------ Build output ------
 
     -i, --image <image>

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -476,9 +476,4 @@ main() {
 
     exit "${EX_OK}"
 }
-
-# Bootstrap
-if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-    # Direct call to file
-    main "$@"
-fi  # Else file is included from another script
+main "$@"

--- a/build-env/rootfs/build.sh
+++ b/build-env/rootfs/build.sh
@@ -1127,7 +1127,7 @@ prepare_dockerfile() {
     [[ ! "${EXISTING_LABELS[*]:-}" = *"io.hass.arch"* ]] \
         && labels+=("io.hass.arch=${BUILD_ARCH}")
 
-    if [[ ${#labels[@]} -ne 0 ]]; then
+    if [[ ! -z "${labels[*]:-}" ]]; then
         IFS=" "
         DOCKERFILE+="LABEL ${labels[*]}"$'\n'
     fi

--- a/build-env/rootfs/build.sh
+++ b/build-env/rootfs/build.sh
@@ -817,10 +817,7 @@ get_info_dockerfile() {
 # ------------------------------------------------------------------------------
 get_info_git() {
     local ref
-    local repo
     local tag
-    local url
-    local user
 
     display_status_message 'Collecting information from GIT'
 

--- a/build-env/rootfs/build.sh
+++ b/build-env/rootfs/build.sh
@@ -1477,7 +1477,6 @@ prepare_defaults() {
 #
 # Globals:
 #   BUILD_LABEL_OVERRIDE
-#   BUILD_LABEL_OVERRIDE
 #   DOCKERFILE
 #   EX_OK
 #   EXISTING_ARGS
@@ -1488,31 +1487,9 @@ prepare_defaults() {
 #   Exit code
 # ------------------------------------------------------------------------------
 prepare_dockerfile() {
-    local inject_from
     local -a labels
 
     display_status_message 'Preparing Dockerfile for use'
-
-    inject_from=false
-
-    DOCKERFILE="${DOCKERFILE//%%ARCH%%/\{arch\}}"
-
-    if grep -q "FROM %%BASE_IMAGE%%" <<< "${DOCKERFILE}"; then
-        DOCKERFILE=$(grep -v "FROM %%BASE_IMAGE%%" <<< "${DOCKERFILE}")
-        inject_from=true
-    fi
-
-    if grep -qE "^#(aarch64|amd64|armhf|i386):FROM .*$" <<< "${DOCKERFILE}"; then
-        DOCKERFILE=$(grep -vE "^#(aarch64|amd64|armhf|i386):FROM .*$" \
-                        <<< "${DOCKERFILE}")
-        inject_from=true
-    fi
-
-    if [[ "${inject_from}" = true ]]; then
-        DOCKERFILE=$(sed "1 i\ARG BUILD_FROM" <<< "${DOCKERFILE}")
-        DOCKERFILE=$(sed "2 i\FROM \$BUILD_FROM" <<< "${DOCKERFILE}")
-        EXISTING_ARGS+=(BUILD_FROM)
-    fi
 
     # Ensure Dockerfile ends with a empty line
     DOCKERFILE+=$'\n'

--- a/build-env/rootfs/build.sh
+++ b/build-env/rootfs/build.sh
@@ -192,18 +192,18 @@ Options:
         Defaults to master.
 
     ------ Build Architectures ------
-    
+
     --aarch64
-        Build for aarch64 architecture.
+        Build for aarch64 (arm 64 bits) architecture.
 
     --amd64
-        Build for amd64 architecture.
+        Build for amd64 (intel/amd 64 bits) architecture.
 
     --armhf
-        Build for armhf architecture.
+        Build for armhf (arm 32 bits) architecture.
 
     --i386
-        Build for i386 architecture.
+        Build for i386 (intel/amd 32 bits) architecture.
 
     -a, --all
         Build for all architectures.
@@ -218,7 +218,7 @@ Options:
         Use a custom base image when building for aarch64.
         e.g. --aarch64-image "homeassistant/aarch64-base".
         Note: This overrides the --from flag for this architecture.
-        
+
     --amd64-from <image>
         Use a custom base image when building for amd64.
         e.g. --amd64-image "homeassistant/amd64-base".

--- a/build-env/rootfs/build.sh
+++ b/build-env/rootfs/build.sh
@@ -811,10 +811,10 @@ preflight_checks() {
         done
     fi
 
-    for arch in "${BUILD_ARCHS[@]}"; do
-        [[ "${BUILD_ARCHS_FROM[${arch}]}" ]] \
-            || display_error_message \
-                "Requested to build for ${arch}, but the image to build from is missing" \
+    for arch in "${SUPPORTED_ARCHS[@]}"; do
+        [[ ! -z $arch && -z "${BUILD_ARCHS_FROM[${arch}]:-}" ]] \
+            && display_error_message \
+                "Architucure ${arch}, is missing a image to build from" \
                 "${EX_NO_FROM}"
     done
 
@@ -918,8 +918,8 @@ main() {
     get_info_dockerfile
 
     # Getting ready
-    preflight_checks
     prepare_defaults
+    preflight_checks
     prepare_dockerfile
 
     # Docker daemon startup

--- a/build-env/rootfs/build.sh
+++ b/build-env/rootfs/build.sh
@@ -411,7 +411,7 @@ docker_build() {
     build_args+=(--tag "${image}:${BUILD_VERSION}")
 
     if [[ "${DOCKER_CACHE}" = true ]]; then
-        build_args+=(--cache-from "${BUILD_IMAGE}:latest")
+        build_args+=(--cache-from "${image}:latest")
     else
         build_args+=(--no-cache)
     fi

--- a/build-env/rootfs/build.sh
+++ b/build-env/rootfs/build.sh
@@ -84,8 +84,6 @@ USE_GIT=false
 # ------------------------------------------------------------------------------
 # Displays a simple program header
 #
-# Globals:
-#   None
 # Arguments:
 #   None
 # Returns:
@@ -100,8 +98,6 @@ display_banner() {
 # ------------------------------------------------------------------------------
 # Displays a error message and is able to terminate te script execution
 #
-# Globals:
-#   None
 # Arguments:
 #   $1 Error message
 #   $2 Exit code, script will continue execution when omitted
@@ -124,8 +120,6 @@ display_error_message() {
 # ------------------------------------------------------------------------------
 # Displays a notice
 #
-# Globals:
-#   None
 # Arguments:
 #   $* Notice message to display
 # Returns:
@@ -142,8 +136,6 @@ display_notice_message() {
 # ------------------------------------------------------------------------------
 # Displays a status message
 #
-# Globals:
-#   None
 # Arguments:
 #   $* Status message to display
 # Returns:
@@ -158,8 +150,6 @@ display_status_message() {
 # ------------------------------------------------------------------------------
 # Displays the help of this program
 #
-# Globals:
-#   EX_OK
 # Arguments:
 #   $1 Exit code
 #   $2 Error message
@@ -258,7 +248,7 @@ Options:
         The type of the thing you are building.
         Valid values are: addon, base, cluster, homeassistant and supervisor.
         If you are unsure, then you probably don't need this flag.
-        Defaults to 'addon'.
+        Defaults to auto detect, with failover to 'addon'.
 
 EOF
 
@@ -272,9 +262,6 @@ EOF
 # ------------------------------------------------------------------------------
 # Cleanup function after execution is of the script is stopped. (trap)
 #
-# Globals:
-#   EX_OK
-#   TRAPPED
 # Arguments:
 #   $1 Exit code
 # Returns:
@@ -296,12 +283,6 @@ cleanup_on_exit() {
 # ------------------------------------------------------------------------------
 # Clones a remote GIT repository to a local working dir
 #
-# Globals:
-#   BUILD_BRANCH
-#   BUILD_REPOSITORY
-#   EX_GIT_CLONE
-#   EX_NOT_EMPTY
-#   EX_OK
 # Arguments:
 #   None
 # Returns:
@@ -326,19 +307,6 @@ clone_repository() {
 # ------------------------------------------------------------------------------
 # Start the Docker build
 #
-# Globals:
-#   BUILD_ARCHS_FROM
-#   BUILD_ARGS
-#   BUILD_IMAGE
-#   BUILD_REF
-#   BUILD_TARGET
-#   BUILD_TYPE
-#   BUILD_VERSION
-#   DOCKER_CACHE
-#   DOCKER_SQUASH
-#   DOCKERFILE
-#   EX_DOCKER_BUILD
-#   EX_OK
 # Arguments:
 #   $1 Architecture to build
 # Returns:
@@ -393,9 +361,6 @@ docker_build() {
 # ------------------------------------------------------------------------------
 # Disables Docker's cross compiler features (qemu)
 #
-# Globals:
-#   EX_CROSS
-#   EX_OK
 # Arguments:
 #   None
 # Returns:
@@ -421,9 +386,6 @@ docker_disable_crosscompile() {
 # ------------------------------------------------------------------------------
 # Enables Docker's cross compiler features (qemu)
 #
-# Globals:
-#   EX_CROSS
-#   EX_OK
 # Arguments:
 #   None
 # Returns:
@@ -444,13 +406,6 @@ docker_enable_crosscompile() {
 # ------------------------------------------------------------------------------
 # Push Docker build result to DockerHub
 #
-# Globals:
-#   BUILD_IMAGE
-#   BUILD_VERSION
-#   DOCKER_TAG_LATEST
-#   DOCKER_TAG_TEST
-#   EX_DOCKER_PUSH
-#   EX_OK
 # Arguments:
 #   $1 Architecture
 # Returns:
@@ -491,11 +446,6 @@ docker_push() {
 # ------------------------------------------------------------------------------
 # Starts the Docker daemon
 #
-# Globals:
-#   DOCKER_PID
-#   DOCKER_TIMEOUT
-#   EX_DOCKER_TIMEOUT
-#   EX_OK
 # Arguments:
 #   None
 # Returns:
@@ -532,11 +482,6 @@ docker_start_daemon() {
 # ------------------------------------------------------------------------------
 # Stops Docker daemon
 #
-# Globals:
-#   DOCKER_PID
-#   DOCKER_TIMEOUT
-#   EX_DOCKER_TIMEOUT
-#   EX_OK
 # Arguments:
 #   None
 # Returns:
@@ -577,13 +522,6 @@ docker_stop_daemon() {
 # ------------------------------------------------------------------------------
 # Places 'latest'/'test' tag(s) onto the current build result
 #
-# Globals:
-#   BUILD_IMAGE
-#   BUILD_VERSION
-#   DOCKER_TAG_LATEST
-#   DOCKER_TAG_TEST
-#   EX_DOCKER_TAG
-#   EX_OK
 # Arguments:
 #   $1 Architecture
 # Returns:
@@ -615,10 +553,6 @@ docker_tag() {
 # ------------------------------------------------------------------------------
 # Try to pull latest version of the current image to use as cache
 #
-# Globals:
-#   BUILD_IMAGE
-#   DOCKER_CACHE
-#   EX_OK
 # Arguments:
 #   $1 Architecture
 # Returns:
@@ -642,15 +576,6 @@ docker_warmup_cache() {
 # ------------------------------------------------------------------------------
 # Tries to fetch information from the add-on config file.
 #
-# Globals:
-#   BUILD_ARCHS_FROM
-#   BUILD_ARGS
-#   BUILD_IMAGE
-#   BUILD_TYPE
-#   BUILD_VERSION
-#   DOCKER_SQUASH
-#   SUPPORTED_ARCHS
-#   EX_OK
 # Arguments:
 #   $1 JSON file to parse
 # Returns:
@@ -708,19 +633,12 @@ get_info_json() {
 # ------------------------------------------------------------------------------
 # Tries to fetch information from existing Dockerfile
 #
-# Globals:
-#   BUILD_TARGET
-#   BUILD_TYPE
-#   DOCKERFILE
-#   EX_OK
-#   EXISTING_LABELS
 # Arguments:
 #   None
 # Returns:
 #   Exit code
 # ------------------------------------------------------------------------------
 get_info_dockerfile() {
-    local from
     local labels
     local json
 
@@ -755,14 +673,6 @@ get_info_dockerfile() {
 # ------------------------------------------------------------------------------
 # Tries to fetch information from the GIT repository
 #
-# Globals:
-#   BUILD_GIT_URL
-#   BUILD_REF
-#   BUILD_URL
-#   BUILD_VERSION
-#   DOCKER_TAG_LATEST
-#   DOCKER_TAG_TEST
-#   EX_OK
 # Arguments:
 #   None
 # Returns:
@@ -808,9 +718,6 @@ get_info_git() {
 # ------------------------------------------------------------------------------
 # Ensure this directory is actually a GIT repository
 #
-# Globals:
-#   EX_GIT
-#   EX_OK
 # Arguments:
 #   None
 # Returns:
@@ -830,23 +737,6 @@ is_git_repository() {
 # ------------------------------------------------------------------------------
 # Parse CLI arguments
 #
-# Globals:
-#   BUILD_ALL
-#   BUILD_ARCHS
-#   BUILD_ARGS
-#   BUILD_BRANCH
-#   BUILD_IMAGE
-#   BUILD_PARALLEL
-#   BUILD_REPOSITORY
-#   BUILD_TARGET
-#   BUILD_URL
-#   DOCKER_CACHE
-#   DOCKER_PUSH
-#   DOCKER_SQUASH
-#   DOCKER_TAG_LATEST
-#   DOCKER_TAG_TEST
-#   EX_UNKNOWN
-#   USE_GIT
 # Arguments:
 #   None
 # Returns:
@@ -934,20 +824,6 @@ parse_cli_arguments() {
 # ------------------------------------------------------------------------------
 # Ensures we have all the information we need to continue building
 #
-# Globals:
-#   BUILD_ALL
-#   BUILD_ARCHS
-#   BUILD_IMAGE
-#   BUILD_TYPE
-#   BUILD_VERSION
-#   EX_INVALID_TYPE
-#   EX_MULTISTAGE
-#   EX_NO_ARCHS
-#   EX_OK
-#   EX_PRIVILEGES
-#   EX_SUPPORTED
-#   EX_VERSION
-#   SUPPORTED_ARCHS
 # Arguments:
 #   None
 # Returns:
@@ -1003,15 +879,6 @@ preflight_checks() {
 # ------------------------------------------------------------------------------
 # Prepares all variables for building use
 #
-# Globals:
-#   BUILD_ALL
-#   BUILD_DOC_URL
-#   BUILD_GIT_URL
-#   BUILD_REF
-#   BUILD_TYPE
-#   BUILD_URL
-#   EX_OK
-#   SUPPORTED_ARCHS
 # Arguments:
 #   None
 # Returns:
@@ -1040,10 +907,6 @@ prepare_defaults() {
 #
 # This is mainly to maintain some form of backwards compatibility
 #
-# Globals:
-#   DOCKERFILE
-#   EX_OK
-#   EXISTING_LABELS
 # Arguments:
 #   None
 # Returns:
@@ -1074,21 +937,6 @@ prepare_dockerfile() {
 
 # ==============================================================================
 # RUN LOGIC
-# ------------------------------------------------------------------------------
-# Globals:
-#   BUILD_ARCHS
-#   BUILD_PARALLEL
-#   BUILD_REPOSITORY
-#   BUILD_TARGET
-#   DOCKER_CACHE
-#   DOCKER_PUSH
-#   EX_DOCKERFILE
-#   EX_OK
-#   USE_GIT
-# Arguments:
-#   None
-# Returns:
-#   None
 # ------------------------------------------------------------------------------
 main() {
     trap 'cleanup_on_exit $?' EXIT SIGINT SIGTERM


### PR DESCRIPTION
# Proposed Changes

This PR simplifies the build environment.
Home Assistant is not going to support most of the futures currently in the environment, therefore, removed a large part of the code base. This PR will put the current codebase up to par with Hass.io 0.64.


## Related Issues

https://github.com/home-assistant/home-assistant.github.io/pull/3406
https://github.com/home-assistant/hassio/pull/191
https://github.com/home-assistant/hassio/issues/198