### PR TITLE
:fire: Removed Git master branch detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning][semantic-versioning].
 
 No unreleased changes yet.
 
+## [v0.3.4][v0.3.4] (2017-09-26)
+
+[Full Changelog][v0.3.3-v0.3.4]
+
+### Removed
+
+- Removed Git master branch detection. [#35][35]
+
 ## [v0.3.3][v0.3.3] (2017-09-26)
 
 [Full Changelog][v0.3.2-v0.3.3]
@@ -205,6 +213,7 @@ No unreleased changes yet.
 [32]: https://github.com/hassio-addons/build-env/pull/32
 [33]: https://github.com/hassio-addons/build-env/pull/33
 [34]: https://github.com/hassio-addons/build-env/pull/34
+[35]: https://github.com/hassio-addons/build-env/pull/35
 [4]: https://github.com/hassio-addons/build-env/pull/4
 [6]: https://github.com/hassio-addons/build-env/pull/6
 [8]: https://github.com/hassio-addons/build-env/pull/8
@@ -241,4 +250,6 @@ No unreleased changes yet.
 [v0.3.1]: https://github.com/hassio-addons/build-env/tree/v0.3.1
 [v0.3.2-v0.3.3]: https://github.com/hassio-addons/build-env/compare/v0.3.2...v0.3.3
 [v0.3.2]: https://github.com/hassio-addons/build-env/tree/v0.3.2
+[v0.3.3-v0.3.4]: https://github.com/hassio-addons/build-env/compare/v0.3.3...v0.3.4
 [v0.3.3]: https://github.com/hassio-addons/build-env/tree/v0.3.3
+[v0.3.4]: https://github.com/hassio-addons/build-env/tree/v0.3.4

--- a/build-env/rootfs/usr/bin/build.sh
+++ b/build-env/rootfs/usr/bin/build.sh
@@ -878,7 +878,6 @@ get_info_dockerfile() {
 #   Exit code
 # ------------------------------------------------------------------------------
 get_info_git() {
-    local branch
     local ref
     local repo
     local tag
@@ -905,18 +904,12 @@ get_info_git() {
     if [[ -z "$(git status --porcelain)" ]]; then
 
         ref=$(git rev-parse --short HEAD)
-        BUILD_REF="${ref}"
-
-        branch=$(git rev-parse --abbrev-ref HEAD)
         tag=$(git describe --exact-match HEAD --abbrev=0 --tags 2> /dev/null \
                 || true)
+        BUILD_REF="${ref}"
 
         # Is current HEAD on a tag and master branch?
-        if [[
-            ! -z "${tag:-}"
-            && "${branch}" = "master"
-            && "${USE_GIT}" = true
-        ]]; then
+        if [[ ! -z "${tag:-}" && "${USE_GIT}" = true ]]; then
             # Is it the latest tag?
             if [[ "$(git describe --abbrev=0 --tags)" = "${tag}" ]]; then
                 DOCKER_TAG_LATEST=true
@@ -925,7 +918,7 @@ get_info_git() {
         else
             # We are clean, but version is unknown, use commit SHA as version
             BUILD_VERSION="${ref}"
-            [[ "${branch}" = "master" ]] && DOCKER_TAG_TEST=true
+            DOCKER_TAG_TEST=true
         fi
 
     else


### PR DESCRIPTION
# Proposed Changes

Removes Git master branch detection because of the following reasons:

- We don't want to dictate the use of the master branch.
- Checking out a tag and sit on HEAD is perfectly valid (CircleCI/TravisCI)

If a project requires being on the master, please ensure you CI scripts handle this well.

## Related Issues

None