### PR TITLE
No docker credsStore in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ own (compatible) Docker instance.
 
 Adding `-v ~/.docker:/root/.docker` shares your Docker hub credentials with
 the built environment. This line may be omitted in case you don't want to
-push your image.
+push your image. Note that this requires that your credentials be stored in
+`docker/config.json` and will not work if you are using a 
+[`credsStore`](docker-credsstore) such as `osxkeychain`.
+
 
 Adding `-v "$(pwd)":/docker` shares your current working directory as the
 directory to start the build process from. This line MUST be omitted in case
@@ -328,6 +331,7 @@ SOFTWARE.
 [discord-shield]: https://img.shields.io/discord/330944238910963714.svg
 [discord]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.gg/c5DvZ4e
+[docker-credsstore]: https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 [dockerhub]: https://hub.docker.com/r/hassioaddons/build-env
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg
 [forum]: https://community.home-assistant.io/?u=frenck


### PR DESCRIPTION

# Proposed Changes

Updating the README to reflect that you can't use `credsStore` in your `.docker/config.json`. This is probably obvious to more experienced docker users given how this works, but I believe it is the default login behavior for Docker for Mac users

## Related Issues

None
